### PR TITLE
Add bc to install dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y curl wget git ruby python3 python3-pip
+sudo apt-get install -y curl wget git ruby python3 python3-pip bc
 python3 -m pip install coloredlogs
 
 # for docker


### PR DESCRIPTION
A barren Kali Linux does not have the bc command.