### PR TITLE
Update install.sh to work on Kali Linux as a normal user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,9 @@ sudo apt-get install -y binwalk mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-f
 git clone https://github.com/devttys0/sasquatch && (cd sasquatch && ./build.sh && cd -)
 git clone https://github.com/devttys0/yaffshiv && (cd yaffshiv && sudo python3 setup.py install)
 sudo cp core/unstuff /usr/local/bin/
+sudo cp core/cramfsck /usr/local/bin/
+sudo cp core/sasquatch /usr/local/bin/
+sudo cp core/yaffshiv /usr/local/bin/
 
 sudo apt-get install -y liblzo2-dev
 sudo python3 -m pip install python-lzo cstruct git+https://github.com/sviehb/jefferson ubi_reader

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y curl wget git ruby python3 python3-pip
-python3 -m pip install coloredlogs
+sudo apt-get install -y curl wget git ruby python3 python3-pip bc
+sudo python3 -m pip install coloredlogs
 
 # for docker
 sudo apt-get install -y docker.io
@@ -16,8 +16,8 @@ sudo -u postgres psql -d firmware < ./database/schema
 echo "listen_addresses = '172.17.0.1,127.0.0.1,localhost'" | sudo -u postgres tee --append /etc/postgresql/*/main/postgresql.conf
 echo "host all all 172.17.0.1/24 trust" | sudo -u postgres tee --append /etc/postgresql/*/main/pg_hba.conf
 
-sudo apt install libpq-dev
-python3 -m pip install psycopg2 psycopg2-binary
+sudo apt install -y libpq-dev
+sudo python3 -m pip install psycopg2 psycopg2-binary pysqlcipher3 
 
 sudo apt-get install -y busybox-static bash-static fakeroot dmsetup kpartx netcat-openbsd nmap python3-psycopg2 snmp uml-utilities util-linux vlan
 
@@ -26,18 +26,19 @@ sudo apt-get install -y binwalk mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-f
 
 git clone https://github.com/devttys0/sasquatch && (cd sasquatch && ./build.sh && cd -)
 git clone https://github.com/devttys0/yaffshiv && (cd yaffshiv && sudo python3 setup.py install)
-cp core/unstuff /usr/local/bin/
+sudo cp core/unstuff /usr/local/bin/
 
-python3 -m pip install python-lzo cstruct git+https://github.com/sviehb/jefferson ubi_reader
+sudo apt-get install -y liblzo2-dev
+sudo python3 -m pip install python-lzo cstruct git+https://github.com/sviehb/jefferson ubi_reader
 sudo apt-get install -y python3-magic openjdk-8-jdk unrar
 
 # for analyzer, initializer
 sudo apt-get install -y python3-bs4
-python3 -m pip install selenium
+sudo python3 -m pip install selenium
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 rm google-chrome-stable_current_amd64.deb
-python3 -m pip install -r ./analyses/routersploit/requirements.txt
+sudo python3 -m pip install -r ./analyses/routersploit/requirements.txt
 cd ./analyses/routersploit && patch -p1 < ../routersploit_patch && cd -
 
 # for qemu


### PR DESCRIPTION
The install.sh had several install steps that were to be run as a normal user (`pip install`). They are now run using `sudo` so that the package is available when running run.sh as sudo. All the binaries from `core` are now copied to `/usr/local/bin`. Also missing dependencies on a clean install were added.

Current problematic packages on Kali Linux:
- fusecram: is not available as a package
- pysqlcipher3: pip install says there are no changed files