### PR TITLE
Update extractor.py to allow binwalk to extract firmware

### DIFF
--- a/sources/extractor/extractor.py
+++ b/sources/extractor/extractor.py
@@ -442,7 +442,7 @@ class ExtractionItem(object):
                                   self.extractor.do_kernel,
                                   self.extractor.do_rootfs))
 
-            for module in binwalk.scan(self.item, "-e", "-r", "-C", self.temp,
+            for module in binwalk.scan(self.item, "--run-as=root", "-e", "-r", "-C", self.temp,
                                        signature=True, quiet=True):
                 prev_entry = None
                 for entry in module.results:


### PR DESCRIPTION
In reference to issue #33:
 
Adding the parameter `"--run-as=root"` to `binwalk.scan` will allow binwalk to be used as expected.