### PR TITLE
Update install to take python packages from repo.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y curl wget tar git ruby python python3 python3-pip bc
-sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install coloredlogs
+sudo apt-get install -y curl wget tar git ruby python2 python3 python3-pip bc python3-coloredlogs python3-pip python3-psycopg2 python3-lzo python3-magic openjdk-17-jdk unrar docker.io postgresql libpq-dev busybox-static bash-static fakeroot dmsetup kpartx netcat-openbsd nmap python3-psycopg2 snmp uml-utilities util-linux vlan mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools sleuthkit default-jdk cpio lzop lzma srecord zlib1g-dev liblzma-dev liblzo2-dev unzip python3-bs4 python3-selenium qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils
 
-# for docker
-sudo apt-get install -y docker.io
+python3 -m pip install cstruct ubi_reader
+
 
 # postgresql
-sudo apt-get install -y postgresql
 sudo /etc/init.d/postgresql restart
 sudo -u postgres bash -c "psql -c \"CREATE USER firmadyne WITH PASSWORD 'firmadyne';\""
 sudo -u postgres createdb -O firmadyne firmware
@@ -17,10 +14,8 @@ sudo -u postgres psql -d firmware < ./database/schema
 echo "listen_addresses = '172.17.0.1,127.0.0.1,localhost'" | sudo -u postgres tee --append /etc/postgresql/*/main/postgresql.conf
 echo "host all all 172.17.0.1/24 trust" | sudo -u postgres tee --append /etc/postgresql/*/main/pg_hba.conf
 
-sudo apt install -y libpq-dev
-python3 -m pip install psycopg2 psycopg2-binary
+# python3 -m pip install psycopg2 psycopg2-binary
 
-sudo apt-get install -y busybox-static bash-static fakeroot dmsetup kpartx netcat-openbsd nmap python3-psycopg2 snmp uml-utilities util-linux vlan
 
 # for binwalk
 wget https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.tar.gz && \
@@ -29,26 +24,19 @@ wget https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.tar.gz && \
   sed -i 's/^install_unstuff//g' deps.sh && \
   echo y | ./deps.sh && \
   sudo python3 setup.py install
-sudo apt-get install -y mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract fusecram cramfsswap squashfs-tools sleuthkit default-jdk cpio lzop lzma srecord zlib1g-dev liblzma-dev liblzo2-dev unzip
+sudo apt-get install -y 
 
 cd - # back to root of project
 
 sudo cp core/unstuff /usr/local/bin/
 
-python3 -m pip install python-lzo cstruct ubi_reader
-sudo apt-get install -y python3-magic openjdk-8-jdk unrar
 
 # for analyzer, initializer
-sudo apt-get install -y python3-bs4
-python3 -m pip install selenium
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb; sudo apt-get -fy install
 rm google-chrome-stable_current_amd64.deb
 python3 -m pip install -r ./analyses/routersploit/requirements.txt
 cd ./analyses/routersploit && patch -p1 < ../routersploit_patch && cd -
-
-# for qemu
-sudo apt-get install -y qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils
 
 if ! test -e "./analyses/chromedriver"; then
     wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip


### PR DESCRIPTION
Do 1 apt install

The packages are installed using 1 apt install. This ensures that conflicts are nicely managed and the installation procedure is a little bit smoother to the user.

Kali 2023.1

With the new release of Kali a new python setup is encouraged. Take the packages from the repository or install them as user. In this patch all the global python packages (where possible) are installed from the repository packages.

https://www.kali.org/blog/kali-linux-2023-1-release/

Obsolete package?

The fusecram package is no longer available in the repositories. It is removed from the apt installation.