### PR TITLE
Update dockerfile to 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 binaries/
 images/
 scratch/
+binwalk-*/
+__pycache__

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,53 +1,45 @@
-FROM ubuntu:18.04
-MAINTAINER Mingeun Kim <pr0v3rbs@kaist.ac.kr>, Minkyo Seo <0xsaika@gmail.com>
-
-RUN apt-get update
-RUN apt-get install -y apt-utils
-RUN apt-get install -y wget tar bc psmisc ruby telnet
-RUN apt-get install -y socat net-tools iputils-ping iptables iproute2 curl
-RUN apt-get install -yy python python3 python3-pip
-RUN python3 -m pip install --upgrade pip
-
-RUN apt-get install -y libpq-dev
-RUN python3 -m pip install psycopg2 psycopg2-binary
-
-RUN apt-get install -y busybox-static bash-static fakeroot git kpartx netcat-openbsd nmap python3-psycopg2 snmp uml-utilities util-linux vlan
-
-# for binwalk
-# bypass tzdata interaction
+FROM --platform=amd64 ubuntu:22.04
+LABEL AUTHOR Mingeun Kim <pr0v3rbs@kaist.ac.kr>, Minkyo Seo <0xsaika@gmail.com>
 ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y wget gnupg2 && \
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+
+RUN apt-get update && apt-get install -y apt-utils wget tar bc psmisc ruby telnet \
+    socat net-tools iputils-ping iptables iproute2 curl \
+    python3 python3-pip python-is-python3 libpq-dev \
+    busybox-static bash-static fakeroot git kpartx netcat-openbsd \
+    nmap python3-psycopg2 snmp uml-utilities util-linux vlan \
+    python3-magic unrar openjdk-8-jdk \
+    mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract \
+    fusecram cramfsswap squashfs-tools sleuthkit default-jdk cpio \
+    lzop lzma srecord zlib1g-dev liblzma-dev liblzo2-dev \
+    qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils \
+    google-chrome-stable ntfs-3g postgresql
+
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install psycopg2 psycopg2-binary python-lzo cstruct ubi_reader \
+    selenium bs4 requests future paramiko pysnmp==4.4.6 pycryptodome
+
 RUN wget https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.4.tar.gz && \
-    tar -xf v2.3.4.tar.gz && \
-    cd binwalk-2.3.4 && \
-    sed -i 's/^install_ubireader//g' deps.sh && \
-    echo y | ./deps.sh && \
-    python3 setup.py install
-RUN apt-get install -y mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract fusecram cramfsswap squashfs-tools sleuthkit default-jdk cpio lzop lzma srecord zlib1g-dev liblzma-dev liblzo2-dev
-
-RUN python3 -m pip install python-lzo cstruct ubi_reader
-RUN apt-get install -y python3-magic unrar
-
-RUN apt-get install -y openjdk-8-jdk
-
-# for qemu
-RUN apt-get install -y qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils
-
-# for analyzer
-RUN python3 -m pip install selenium bs4 requests future paramiko pysnmp==4.4.6 pycryptodome
-# google chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-RUN apt-get update
-RUN apt-get install -y google-chrome-stable
-RUN apt-get install -y ntfs-3g
-RUN ln -s /bin/ntfs-3g /bin/mount.ntfs-3g
+  tar -xf v2.3.4.tar.gz && \
+  cd binwalk-2.3.4 && \
+  sed -i 's/^install_ubireader//g;s/^install_sasquatch//g' deps.sh && \
+  git clone --quiet --depth 1 --branch "master" https://github.com/devttys0/sasquatch && \
+  cd sasquatch && \
+  wget https://github.com/devttys0/sasquatch/pull/51.patch && patch -p1 <51.patch && \
+  ./build.sh && cd .. && \
+  echo y | ./deps.sh && \
+  python3 setup.py install
 
 COPY ./sudo /usr/bin/sudo
-RUN chmod 777 /usr/bin/sudo
 
-RUN mkdir -p /work/FirmAE
-RUN mkdir -p /work/firmwares
-COPY unstuff /usr/local/bin/
+RUN ln -s /bin/ntfs-3g /bin/mount.ntfs-3g && \
+    chmod 777 /usr/bin/sudo && \
+    mkdir -p /work/FirmAE && \
+    mkdir -p /work/firmwares && \
+    unstuff /usr/local/bin/
 
 ENV USER=root
 ENV FIRMAE_DOCKER=true

--- a/docker-helper.py
+++ b/docker-helper.py
@@ -49,15 +49,15 @@ class docker_helper:
                 -v /dev:/dev \\
                 -v {0}:/work/FirmAE \\
                 -v {1}:/work/firmwares \\
-                --privileged=true \\
+                --privileged \\
                 --name {2} \\
+                -p '5432:5432' \\
                 fcore""".format(self.firmae_root,
                                 firmware_root,
                                 docker_name)
-
+        print(cmd)
         sp.check_output(cmd, shell=True)
         logging.info("[*] {} emulation start!".format(docker_name))
-        time.sleep(5)
 
         docker_mode = "-it" if mode == "-d" else "-id"
         cmd = "docker exec {0} \"{1}\" ".format(docker_mode, docker_name)
@@ -72,6 +72,7 @@ class docker_helper:
 
         t0 = time.time()
         iid = -1
+        print(cmd)
         if mode == "-d":
             os.system(cmd)
         else:
@@ -93,7 +94,7 @@ class docker_helper:
                 f.readline()
                 last_line = f.readline()
                 if last_line.find("container failed") != -1:
-                    logging.error("[-] %s container failed to connect to the hosts' postgresql".format(docker_name))
+                    logging.error("[-] {} container failed to connect to the hosts' postgresql".format(docker_name))
                     return docker_name
 
         if not iid:

--- a/host-init.sh
+++ b/host-init.sh
@@ -1,0 +1,12 @@
+# Tested on MacOS under `brew install postgresql@14`
+createdb -U firmadyne
+psql -c "CREATE USER firmadyne WITH PASSWORD 'firmadyne';"
+createdb -O firmadyne firmware
+psql -d firmware < ./database/schema
+CONFIG_LOCATION=$(psql -c 'SHOW config_file;' -t -A)
+HBA_LOCATION=$(psql -c 'SHOW hba_file;' -t -A)
+echo "$CONFIG_LOCATION, $HBA_LOCATION"
+echo "listen_addresses = '172.17.0.1,127.0.0.1,localhost'" | tee -a $CONFIG_LOCATION
+echo "host all all 172.17.0.1/24 trust" | tee -a $HBA_LOCATION
+
+echo "[*] Completed initializing database for docker to connect to"


### PR DESCRIPTION
- Update dockerfile to 22.04

The best practice for dockerfiles is to use as few layers as possible to minimize image size. I have rolled all the `apt-get`, and `pip` steps together. I also fixed an issue with installing binwalk.